### PR TITLE
Use tagged releases for VASM

### DIFF
--- a/Formula/vasm-all.rb
+++ b/Formula/vasm-all.rb
@@ -1,8 +1,8 @@
 class VasmAll < Formula
   desc "vasm portable and retargetable assembler."
   homepage "http://sun.hasenbraten.de/vasm/"
-  url "http://sun.hasenbraten.de/vasm/release/vasm.tar.gz"
-  version "1.8f"
+  url "http://phoenix.owl.de/tags/vasm1_8h.tar.gz"
+  version "1.8h"
   sha256 "2b7aba9b6d0a196a2ab009fbed08f10acd94da41d11d3a224cb59b2a6c2f2b41"
   
   def install

--- a/Formula/vasm-all.rb
+++ b/Formula/vasm-all.rb
@@ -1,12 +1,12 @@
 class VasmAll < Formula
   desc "vasm portable and retargetable assembler."
   homepage "http://sun.hasenbraten.de/vasm/"
-  url "http://phoenix.owl.de/tags/vasm1_8h.tar.gz"
-  version "1.8h"
-  sha256 "2b7aba9b6d0a196a2ab009fbed08f10acd94da41d11d3a224cb59b2a6c2f2b41"
+  url "http://phoenix.owl.de/tags/vasm1_8j.tar.gz"
+  version "1.8j"
+  sha256 "8b8b78091d82a92769778b2964e64c4fb98e969b46d65708dcf88f6957072676"
   
   def install
-    cpus = %w{6502 6800 arm c16x jagrisc m68k ppc qnice tr3200 vidcore x86 z80}
+    cpus = %w{6502 6800 6809 arm c16x jagrisc m68k pdp11 ppc qnice tr3200 vidcore x86 z80}
     syntaxes = %w{mot std madmac oldstyle}
 
     cpus.product(syntaxes).each do |(cpu, syntax)|


### PR DESCRIPTION
This uses the tagged releases for building VASM. The first commit updated the URL to point to the version that had the SHA that matched, the second switches to the latest release, and adds the new CPUs to the list to make (since this is vasm-all, I figured it made more sense to be complete, even though there's an issue to only do m68k).

This should fix https://github.com/rosco-m68k/homebrew-toolchain/issues/2, https://github.com/rosco-m68k/homebrew-toolchain/issues/3, https://github.com/rosco-m68k/homebrew-toolchain/issues/7, and https://github.com/rosco-m68k/rosco_m68k/issues/176.

Seems odd that the tagged releases are on a different domain.