### PR TITLE
Add GCC 11.2.0 and update Binutils to 2.37

### DIFF
--- a/Formula/binutils-cross-m68k.rb
+++ b/Formula/binutils-cross-m68k.rb
@@ -1,8 +1,8 @@
 class BinutilsCrossM68k < Formula
   desc "GNU Binutils for m68k cross-compiling"
   homepage "https://www.gnu.org/software/binutils/"
-  url "http://www.mirrorservice.org/sites/ftp.gnu.org/gnu/binutils/binutils-2.28.tar.bz2"
-  sha256 "6297433ee120b11b4b0a1c8f3512d7d73501753142ab9e2daa13c5a3edd32a72"
+  url "http://www.mirrorservice.org/sites/ftp.gnu.org/gnu/binutils/binutils-2.37.tar.bz2"
+  sha256 "67fc1a4030d08ee877a4867d3dcab35828148f87e1fd05da6db585ed5a166bd4"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/gcc-cross-m68k@11.1.0-RC-20210420.rb
+++ b/Formula/gcc-cross-m68k@11.1.0-RC-20210420.rb
@@ -1,0 +1,61 @@
+class GccCrossM68kAT1110Rc20210420 < Formula
+  desc "GNU Compiler Collection 11.1.0-RC-20210420 (Cross-compiler/m68k)"
+  homepage "https://gcc.gnu.org"
+  url "https://gcc.gnu.org/pub/gcc/snapshots/11.1.0-RC-20210420/gcc-11.1.0-RC-20210420.tar.gz"
+  sha256 "e3fd6b4f35deeaf6f2a1283018bfc13b9970a2f2ef484a5c32c99417e0117dd8"
+
+  depends_on "binutils-cross-m68k"
+  
+  # All of these are probably not needed but #3 was a case where it wouldn't
+  # build without them (maybe no previous install of platform GCC)
+  depends_on "gmp"
+  depends_on "isl"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run so pretend we have an outdated makeinfo
+    # to prevent their build.
+    ENV["gcc_cv_prog_makeinfo_modern"] = "no"
+    
+    args = [
+      "--disable-debug",
+      "--disable-dependency-tracking",
+      "--disable-silent-rules",
+      "--target=m68k-elf",
+      "--enable-languages=c,c++",
+      "--disable-nls",
+      "--with-as=#{Formula["binutils-cross-m68k"].opt_bin}/m68k-elf-as",
+      "--with-ld=#{Formula["binutils-cross-m68k"].opt_bin}/m68k-elf-ld",
+      "--prefix=#{prefix}"
+    ]
+    
+    mkdir "../build" do
+      system "../gcc-11.1.0-RC-20210420/configure", *args
+      system "make", "all-gcc", "all-target-libgcc"
+      system "make", "install-gcc", "install-target-libgcc"
+    end
+  end
+
+  test do
+    (testpath/"hello-c.c").write <<~EOS
+      int main()
+      {
+        return 0;
+      }
+    EOS
+    system "#{bin}/m68k-elf-gcc", "-ffreestanding", "-c", "-o", "hello-c.o", "hello-c.c"
+
+    (testpath/"hello-cc.cc").write <<~EOS
+      int main()
+      {
+        return 0;
+      }
+    EOS
+    system "#{bin}/m68k-elf-g++", "-ffreestanding", "-c", "-o", "hello-cc.o", "hello-cc.cc"
+  end
+end

--- a/Formula/gcc-cross-m68k@11.rb
+++ b/Formula/gcc-cross-m68k@11.rb
@@ -1,8 +1,8 @@
-class GccCrossM68kAT1110Rc20210420 < Formula
-  desc "GNU Compiler Collection 11.1.0-RC-20210420 (Cross-compiler/m68k)"
+class GccCrossM68kAT11 < Formula
+  desc "GNU Compiler Collection 11.2.0 (Cross-compiler/m68k)"
   homepage "https://gcc.gnu.org"
-  url "https://gcc.gnu.org/pub/gcc/snapshots/11.1.0-RC-20210420/gcc-11.1.0-RC-20210420.tar.gz"
-  sha256 "e3fd6b4f35deeaf6f2a1283018bfc13b9970a2f2ef484a5c32c99417e0117dd8"
+  url "http://www.mirrorservice.org/sites/ftp.gnu.org/gnu/gcc/gcc-11.2.0/gcc-11.2.0.tar.gz"
+  sha256 "f0837f1bf8244a5cc23bd96ff6366712a791cfae01df8e25b137698aca26efc1"
 
   depends_on "binutils-cross-m68k"
   
@@ -35,7 +35,7 @@ class GccCrossM68kAT1110Rc20210420 < Formula
     ]
     
     mkdir "../build" do
-      system "../gcc-11.1.0-RC-20210420/configure", *args
+      system "../gcc-#{version}/configure", *args
       system "make", "all-gcc", "all-target-libgcc"
       system "make", "install-gcc", "install-target-libgcc"
     end


### PR DESCRIPTION
Binutils has had the version and hash updated.

The added GCC 11 file should be identical to the GCC 10 one, aside from the updated version and hash.

Hopefully these still work since when I last tested the installation. 🤞 

