### PR TITLE
Add texinfo dependency for homebrew

### DIFF
--- a/Formula/binutils-cross-m68k.rb
+++ b/Formula/binutils-cross-m68k.rb
@@ -4,6 +4,8 @@ class BinutilsCrossM68k < Formula
   url "http://www.mirrorservice.org/sites/ftp.gnu.org/gnu/binutils/binutils-2.40.tar.bz2"
   sha256 "f8298eb153a4b37d112e945aa5cb2850040bcf26a3ea65b5a715c83afe05e48a"
 
+  depends_on "texinfo" => :build
+  
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
Malcolm Harrow figured out this formula fix, works nicely manually.  The hope is if this is officially merged it will allow `brew upgrade` to work (upgrading GCC depends on this and has been tripping over texinfo issue).