### PR TITLE
Hail-Mary play to try and work around weird installer non-error

### DIFF
--- a/Formula/rosco-m68k-toolchain@13.rb
+++ b/Formula/rosco-m68k-toolchain@13.rb
@@ -58,9 +58,12 @@ class RoscoM68kToolchainAT13 < Formula
         "install-binutils",
         "install-gas",
         "install-ld",
-        "install-gcc",
-        "install-target-libgcc",
-        "install-target-newlib",
+        "install-gcc"
+      system "make",
+        "install-target-libgcc"
+      system "make",
+        "install-target-newlib"
+      system "make",
         "install-target-libgloss"
     end
   end


### PR DESCRIPTION
We noticed that the install step is failing, with no error, immediately after the `install-gcc` target.

This seemed to maybe fix it on my local, and I have literally no idea why that might be the case.... 🤷 